### PR TITLE
Fix request_url_without_up_params to properly detect _up_ query params

### DIFF
--- a/lib/unpoly/rails/change.rb
+++ b/lib/unpoly/rails/change.rb
@@ -279,7 +279,9 @@ module Unpoly
       def request_url_without_up_params
         original_url = request.original_url
 
-        original_url.include?(Field::PARAM_PREFIX) or return original_url
+        query_presence_index = original_url.index("?")
+        return original_url if query_presence_index.nil?
+        return original_url if original_url.index(Field::PARAM_PREFIX, query_presence_index).nil?
 
         # Parse the URL to extract the ?query part below.
         uri = URI.parse(original_url)

--- a/spec/unpoly/rails/change_spec.rb
+++ b/spec/unpoly/rails/change_spec.rb
@@ -1,0 +1,31 @@
+describe Unpoly::Rails::Change do
+  describe "request_url_without_up_params" do
+    let :controller do
+      Struct.new(:request).new(Struct.new(:original_url).new("https://example.com/"))
+    end
+
+    it "returns uri without _up_ params" do
+      controller.request.original_url = "https://example.com/some/path?_up_target=the-target&param1=1"
+      change = Unpoly::Rails::Change.new(controller)
+      expect(change.request_url_without_up_params).to eq("/some/path?param1=1")
+    end
+
+    it "returns original_url when no params match _up_" do
+      controller.request.original_url = "https://example.com/some/path?param1=1"
+      change = Unpoly::Rails::Change.new(controller)
+      expect(change.request_url_without_up_params).to eq(controller.request.original_url)
+    end
+
+    it "returns original_url when only the path matches _up_" do
+      controller.request.original_url = "https://example.com/some_sign_up_path?param1=1"
+      change = Unpoly::Rails::Change.new(controller)
+      expect(change.request_url_without_up_params).to eq(controller.request.original_url)
+    end
+
+    it "returns uri when when path and some params match _up_" do
+      controller.request.original_url = "https://example.com/some_sign_up_path?_up_target=some-target&param1=1&param2=2"
+      change = Unpoly::Rails::Change.new(controller)
+      expect(change.request_url_without_up_params).to eq("/some_sign_up_path?param1=1&param2=2")
+    end
+  end
+end


### PR DESCRIPTION
Former implementation did try to remove _up_ query params even when only the path of the url matched.
Fix for #4 